### PR TITLE
Connection pool mechanism

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,5 +18,6 @@
       <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.0" />
       <PackageVersion Include="JetBrains.Annotations" Version="2018.2.1" />
       <PackageVersion Include="Shouldly" Version="3.0.1" />
+      <PackageVersion Include="Moq" Version="4.20.70" />
     </ItemGroup>
   </Project>

--- a/src/progaudi.tarantool/Core/ConnectionTimeoutThresholdReachedEventArgs.cs
+++ b/src/progaudi.tarantool/Core/ConnectionTimeoutThresholdReachedEventArgs.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace ProGaudi.Tarantool.Client.Core
+{
+    public class ConnectionTimeoutThresholdReachedEventArgs : EventArgs
+    {
+        public uint TimeoutCount { get; set; }
+    }
+}

--- a/src/progaudi.tarantool/Core/ConnectionWentDownEventArgs.cs
+++ b/src/progaudi.tarantool/Core/ConnectionWentDownEventArgs.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Linq;
+using ProGaudi.Tarantool.Client.Model;
+
+namespace ProGaudi.Tarantool.Client.Core
+{
+    public class ConnectionWentDownEventArgs : EventArgs
+    {
+        public ConnectionWentDownEventArgs(TarantoolNode node)
+        {
+            Node = node;
+        }
+        
+        public ConnectionWentDownEventArgs(ClientOptions clientOptions)
+        {
+            Node = clientOptions.ConnectionOptions.Nodes.FirstOrDefault();
+        }
+        
+        public TarantoolNode Node { get; private set; }
+    }
+}

--- a/src/progaudi.tarantool/Core/ConnectionWentUpEventArgs.cs
+++ b/src/progaudi.tarantool/Core/ConnectionWentUpEventArgs.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace ProGaudi.Tarantool.Client.Core
+{
+    public class ConnectionWentUpEventArgs : EventArgs
+    {
+        public IBox Box { get; set; }
+        public string ConnectionKey { get; set; }
+    }
+}

--- a/src/progaudi.tarantool/Core/ILogicalConnection.cs
+++ b/src/progaudi.tarantool/Core/ILogicalConnection.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Threading.Tasks;
-
 using ProGaudi.Tarantool.Client.Model.Requests;
 using ProGaudi.Tarantool.Client.Model.Responses;
 
-namespace ProGaudi.Tarantool.Client
+namespace ProGaudi.Tarantool.Client.Core
 {
     public interface ILogicalConnection : IDisposable
     {

--- a/src/progaudi.tarantool/Core/IPhysicalConnection.cs
+++ b/src/progaudi.tarantool/Core/IPhysicalConnection.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using ProGaudi.Tarantool.Client.Model;
 
-namespace ProGaudi.Tarantool.Client
+namespace ProGaudi.Tarantool.Client.Core
 {
     public interface IPhysicalConnection : IDisposable
     {

--- a/src/progaudi.tarantool/Core/IRequestWriter.cs
+++ b/src/progaudi.tarantool/Core/IRequestWriter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Threading.Tasks;
 
-namespace ProGaudi.Tarantool.Client
+namespace ProGaudi.Tarantool.Client.Core
 {
     internal interface IRequestWriter : IDisposable
     {

--- a/src/progaudi.tarantool/Core/IResponseReader.cs
+++ b/src/progaudi.tarantool/Core/IResponseReader.cs
@@ -1,10 +1,9 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-
 using ProGaudi.Tarantool.Client.Model;
 
-namespace ProGaudi.Tarantool.Client
+namespace ProGaudi.Tarantool.Client.Core
 {
     public interface IResponseReader : IDisposable
     {

--- a/src/progaudi.tarantool/Core/NetworkStreamPhysicalConnection.cs
+++ b/src/progaudi.tarantool/Core/NetworkStreamPhysicalConnection.cs
@@ -3,15 +3,13 @@ using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-
 using ProGaudi.Tarantool.Client.Model;
 using ProGaudi.Tarantool.Client.Utils;
-
 #if PROGAUDI_NETCORE
 using System.Net;
 #endif
 
-namespace ProGaudi.Tarantool.Client
+namespace ProGaudi.Tarantool.Client.Core
 {
     internal class NetworkStreamPhysicalConnection : IPhysicalConnection
     {

--- a/src/progaudi.tarantool/Core/RequestIdCounter.cs
+++ b/src/progaudi.tarantool/Core/RequestIdCounter.cs
@@ -1,8 +1,7 @@
 ﻿using System.Threading;
-
 using ProGaudi.Tarantool.Client.Model;
 
-namespace ProGaudi.Tarantool.Client
+namespace ProGaudi.Tarantool.Client.Core
 {
     public class RequestIdCounter
     {

--- a/src/progaudi.tarantool/Core/RequestWriter.cs
+++ b/src/progaudi.tarantool/Core/RequestWriter.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
 using ProGaudi.Tarantool.Client.Model;
 
-namespace ProGaudi.Tarantool.Client
+namespace ProGaudi.Tarantool.Client.Core
 {
     internal class RequestWriter : IRequestWriter
     {

--- a/src/progaudi.tarantool/Core/ResponseReader.cs
+++ b/src/progaudi.tarantool/Core/ResponseReader.cs
@@ -4,9 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using JetBrains.Annotations;
-
 using ProGaudi.MsgPack.Light;
 using ProGaudi.Tarantool.Client.Model;
 using ProGaudi.Tarantool.Client.Model.Enums;
@@ -14,7 +12,7 @@ using ProGaudi.Tarantool.Client.Model.Headers;
 using ProGaudi.Tarantool.Client.Model.Responses;
 using ProGaudi.Tarantool.Client.Utils;
 
-namespace ProGaudi.Tarantool.Client
+namespace ProGaudi.Tarantool.Client.Core
 {
     internal class ResponseReader : IResponseReader
     {

--- a/src/progaudi.tarantool/IBox.cs
+++ b/src/progaudi.tarantool/IBox.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
+using ProGaudi.Tarantool.Client.Core;
 using ProGaudi.Tarantool.Client.Model;
+using ProGaudi.Tarantool.Client.Model.Requests;
 using ProGaudi.Tarantool.Client.Model.Responses;
 
 namespace ProGaudi.Tarantool.Client
@@ -47,5 +49,11 @@ namespace ProGaudi.Tarantool.Client
         Task<DataResponse<TResponse[]>> ExecuteSql<TResponse>(string query, params SqlParameter[] parameters);
 
         Task<DataResponse> ExecuteSql(string query, params SqlParameter[] parameters);
+
+        Task Do<TRequest>(TRequest request) where TRequest : IRequest;
+
+        Task<DataResponse<TResponse[]>> Do<TRequest, TResponse>(TRequest request) where TRequest : IRequest;
+        
+        event EventHandler<ConnectionWentDownEventArgs> ConnectionGoesDown;
     }
 }

--- a/src/progaudi.tarantool/IIndex.cs
+++ b/src/progaudi.tarantool/IIndex.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using ProGaudi.Tarantool.Client.Core;
 using ProGaudi.Tarantool.Client.Model;
 using ProGaudi.Tarantool.Client.Model.Enums;
 using ProGaudi.Tarantool.Client.Model.Responses;

--- a/src/progaudi.tarantool/ISpace.cs
+++ b/src/progaudi.tarantool/ISpace.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using ProGaudi.Tarantool.Client.Core;
 using ProGaudi.Tarantool.Client.Model;
 using ProGaudi.Tarantool.Client.Model.Enums;
 using ProGaudi.Tarantool.Client.Model.Responses;

--- a/src/progaudi.tarantool/Index.cs
+++ b/src/progaudi.tarantool/Index.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
+using ProGaudi.Tarantool.Client.Core;
 using ProGaudi.Tarantool.Client.Model;
 using ProGaudi.Tarantool.Client.Model.Enums;
 using ProGaudi.Tarantool.Client.Model.Requests;

--- a/src/progaudi.tarantool/Model/BoxInfo.cs
+++ b/src/progaudi.tarantool/Model/BoxInfo.cs
@@ -11,9 +11,9 @@ namespace ProGaudi.Tarantool.Client.Model
 
         public long Pid { get; private set; }
 
-        public bool ReadOnly { get; private set; }
+        public virtual bool ReadOnly { get; private set; }
 
-        public Guid Uuid { get; private set; }
+        public virtual Guid Uuid { get; private set; }
 
         public TarantoolVersion Version { get; private set; }
 

--- a/src/progaudi.tarantool/Model/ClientOptions.cs
+++ b/src/progaudi.tarantool/Model/ClientOptions.cs
@@ -16,7 +16,7 @@ namespace ProGaudi.Tarantool.Client.Model
         {
         }
 
-        private ClientOptions(ConnectionOptions options, ILog log, MsgPackContext context)
+        public ClientOptions(ConnectionOptions options, ILog log, MsgPackContext context)
         {
             ConnectionOptions = options;
             MsgPackContext = context ?? new MsgPackContext(binaryCompatibilityMode: true);

--- a/src/progaudi.tarantool/Model/ConnectionPoolOptions.cs
+++ b/src/progaudi.tarantool/Model/ConnectionPoolOptions.cs
@@ -1,0 +1,9 @@
+namespace ProGaudi.Tarantool.Client.Model
+{
+    public class ConnectionPoolOptions
+    {
+        public bool ShuffleNodes { get; set; } = true;
+
+        public int ReconnectIntervalInSeconds { get; set; } = 5;
+    }
+}

--- a/src/progaudi.tarantool/Model/Metrics.cs
+++ b/src/progaudi.tarantool/Model/Metrics.cs
@@ -1,4 +1,6 @@
-﻿namespace ProGaudi.Tarantool.Client.Model
+﻿using ProGaudi.Tarantool.Client.Core;
+
+namespace ProGaudi.Tarantool.Client.Model
 {
     public class Metrics
     {

--- a/src/progaudi.tarantool/Model/TarantoolNode.cs
+++ b/src/progaudi.tarantool/Model/TarantoolNode.cs
@@ -9,7 +9,7 @@ namespace ProGaudi.Tarantool.Client.Model
         {
         }
 
-        private TarantoolNode([NotNull] string url)
+        public TarantoolNode([NotNull] string url)
         {
             if (string.IsNullOrEmpty(url))
                 throw new ArgumentException("Value cannot be null or empty.", nameof(url));

--- a/src/progaudi.tarantool/Pool/ConnectionPool.cs
+++ b/src/progaudi.tarantool/Pool/ConnectionPool.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ProGaudi.Tarantool.Client.Core;
+using ProGaudi.Tarantool.Client.Model;
+using ProGaudi.Tarantool.Client.Model.Enums;
+using ProGaudi.Tarantool.Client.Model.Requests;
+using ProGaudi.Tarantool.Client.Model.Responses;
+using ProGaudi.Tarantool.Client.Model.UpdateOperations;
+
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    public class ConnectionPool : IConnectionPool
+    {
+        private readonly IPoolStrategy<string, IBox> _roPool;
+        private readonly IPoolStrategy<string, IBox> _rwPool;
+        private readonly IPoolStrategy<string, IBox> _anyPool;
+        private readonly Dictionary<TarantoolNode, IBox> _connectionsByNodes;
+        private readonly ConnectionPoolOptions _poolOptions;
+        private readonly ITarantoolNodesSource _nodesSource;
+        private readonly IBoxFactory _boxFactory;
+        
+        public ConnectionPool(ConnectionPoolOptions poolOptions, 
+            ITarantoolNodesSource nodesSource, IBoxFactory boxFactory)
+        {
+            _poolOptions = poolOptions;
+            _roPool = new RoundRobinPool<string, IBox>();
+            _rwPool = new RoundRobinPool<string, IBox>();
+            _anyPool = new RoundRobinPool<string, IBox>();
+            _connectionsByNodes = new Dictionary<TarantoolNode, IBox>();
+            _nodesSource = nodesSource;
+            _boxFactory = boxFactory;
+            Status = PoolStatus.Unknown;
+            
+            var somebodyAlive = FillThePools();
+            Status = !somebodyAlive ? PoolStatus.Closed : PoolStatus.Connected;
+        }
+        
+        public PoolStatus Status { get; private set; }
+
+        public async Task Call(string functionName, RequestMode mode)
+        {
+            var box = GetNextConnection(mode);
+            await box.Call(functionName);
+        }
+
+        public async Task Call<TTuple>(string functionName, TTuple parameters, RequestMode mode)
+        {
+            var box = GetNextConnection(mode);
+            await box.Call(functionName, parameters);
+        }
+
+        public async Task<DataResponse<TResponse[]>> Call<TResponse>(string functionName, RequestMode mode)
+        {
+            var box = GetNextConnection(mode);
+            return await box.Call<TResponse>(functionName);
+        }
+
+        public async Task<DataResponse<TResponse[]>> Call<TTuple, TResponse>(string functionName, TTuple parameters, RequestMode mode)
+        {
+            var box = GetNextConnection(mode);
+            return await box.Call<TTuple, TResponse>(functionName, parameters);
+        }
+
+        public async Task<DataResponse<TResponse[]>> Eval<TTuple, TResponse>(string expression, TTuple parameters, RequestMode mode)
+        {
+            var box = GetNextConnection(mode);
+            return await box.Eval<TTuple, TResponse>(expression, parameters);
+        }
+
+        public async Task<DataResponse<TResponse[]>> Eval<TResponse>(string expression, RequestMode mode)
+        {
+            var box = GetNextConnection(mode);
+            return await box.Eval<TResponse>(expression);
+        }
+
+        public async Task<DataResponse> ExecuteSql(string query, RequestMode mode, params SqlParameter[] parameters)
+        {
+            var box = GetNextConnection(mode);
+            return await box.ExecuteSql(query, parameters);
+        }
+
+        public async Task<DataResponse<TResponse[]>> ExecuteSql<TResponse>(string query, RequestMode mode, params SqlParameter[] parameters)
+        {
+            var box = GetNextConnection(mode);
+            return await box.ExecuteSql<TResponse>(query, parameters);
+        }
+
+        public async Task<DataResponse<TTuple[]>> Insert<TTuple>(uint spaceId, TTuple tuple, RequestMode mode = RequestMode.Rw)
+        {
+            var insertRequest = new InsertRequest<TTuple>(spaceId, tuple);
+            return await Do<InsertRequest<TTuple>, TTuple>(insertRequest, mode);
+        }
+
+        public async Task<DataResponse<TTuple[]>> Select<TKey, TTuple>(uint spaceId, TKey selectKey, RequestMode mode = RequestMode.Any)
+        {
+            var selectRequest = new SelectRequest<TKey>(spaceId, Schema.PrimaryIndexId, uint.MaxValue, 0, Iterator.Eq, selectKey);
+            return await Do<SelectRequest<TKey>, TTuple>(selectRequest, mode);
+        }
+
+        public async Task<TTuple> Get<TKey, TTuple>(uint spaceId, TKey key, RequestMode mode = RequestMode.Any)
+        {
+            var selectRequest = new SelectRequest<TKey>(spaceId, Schema.PrimaryIndexId, 1, 0, Iterator.Eq, key);
+            var response = await Do<SelectRequest<TKey>, TTuple>(selectRequest, mode);
+            return response.Data.SingleOrDefault();
+        }
+
+        public async Task<DataResponse<TTuple[]>> Replace<TTuple>(uint spaceId, TTuple tuple, RequestMode mode = RequestMode.Rw)
+        {
+            var replaceRequest = new ReplaceRequest<TTuple>(spaceId, tuple);
+            return await Do<InsertReplaceRequest<TTuple>, TTuple>(replaceRequest, mode);
+        }
+
+        public async Task<DataResponse<TTuple[]>> Update<TKey, TTuple>(uint spaceId, TKey key, UpdateOperation[] updateOperations,
+            RequestMode mode = RequestMode.Rw)
+        {
+            var updateRequest = new UpdateRequest<TKey>(spaceId, Schema.PrimaryIndexId, key, updateOperations);
+            return await Do<UpdateRequest<TKey>, TTuple>(updateRequest, mode);
+        }
+
+        public async Task Upsert<TTuple>(uint spaceId, TTuple tuple, UpdateOperation[] updateOperations, RequestMode mode = RequestMode.Rw)
+        {
+            var upsertRequest = new UpsertRequest<TTuple>(spaceId, tuple, updateOperations);
+            await Do(upsertRequest, mode);
+        }
+
+        public async Task<DataResponse<TTuple[]>> Delete<TKey, TTuple>(uint spaceId, TKey key, RequestMode mode = RequestMode.Rw)
+        {
+            var deleteRequest = new DeleteRequest<TKey>(spaceId, Schema.PrimaryIndexId, key);
+            return await Do<DeleteRequest<TKey>, TTuple>(deleteRequest, mode);
+        }
+
+        public async Task Do<TRequest>(TRequest request, RequestMode mode) where TRequest : IRequest
+        {
+            var box = GetNextConnection(mode);
+            await box.Do(request);
+        }
+
+        public async Task<DataResponse<TResponse[]>> Do<TRequest, TResponse>(TRequest request, RequestMode mode) where TRequest : IRequest
+        {
+            var box = GetNextConnection(mode);
+            return await box.Do<TRequest, TResponse>(request);
+        }
+        
+        private bool FillThePools()
+        {
+            var somebodyAlive = false;
+
+            var nodes = _nodesSource.GetNodes().ConfigureAwait(false).GetAwaiter().GetResult();
+            if (_poolOptions.ShuffleNodes)
+            {
+                var rng = new Random();
+                nodes = nodes.OrderBy(a => rng.Next()).ToList();
+            }
+
+            Parallel.ForEach(nodes, node =>
+            {
+                var box = _boxFactory.Create(node);
+                
+                try
+                {
+                    box.Connect().ConfigureAwait(false).GetAwaiter().GetResult();
+                }
+                catch
+                {
+                    // ignored
+                }
+
+                _connectionsByNodes[node] = box;
+                
+                if (box.IsConnected)
+                {
+                    box.ConnectionGoesDown += ConnectionWentDownHandler;
+                    AddConnection(node.Uri.ToString(), box);
+                    somebodyAlive = true;
+                }
+                else
+                {
+                    AddToReconnectingPool(node.Uri.ToString(), box);
+                }
+            });
+
+            return somebodyAlive;
+        }
+
+        private void AddConnection(string address, IBox box)
+        {
+            _anyPool.Add(address, box);
+            if (box.Info.ReadOnly)
+            {
+                _roPool.Add(address, box);
+            }
+            else
+            {
+                _rwPool.Add(address, box);
+            }
+        }
+        
+        private void DeleteConnection(string address)
+        {
+            _anyPool.DeleteByKey(address);
+            _roPool.DeleteByKey(address);
+            _rwPool.DeleteByKey(address);
+            if (_anyPool.IsEmpty())
+            {
+                Status = PoolStatus.Closed;
+            }
+        }
+
+        private IBox GetNextConnection(RequestMode mode)
+        {
+            IBox next;
+            switch (mode)
+            {
+                case RequestMode.Any:
+                    next = _anyPool.GetNext();
+                    break;
+                case RequestMode.Rw:
+                    next = _rwPool.GetNext();
+                    break;
+                case RequestMode.Ro:
+                    next = _roPool.GetNext();
+                    break;
+                case RequestMode.PreferRw:
+                    next = _rwPool.GetNext() ?? _roPool.GetNext();
+                    break;
+                case RequestMode.PreferRo:
+                    next = _roPool.GetNext() ?? _rwPool.GetNext();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+            }
+
+            if (next == null)
+            {
+                throw new NoHealthyNodeException();
+            }
+
+            return next;
+        }
+        
+        private void ConnectionWentDownHandler(object sender, ConnectionWentDownEventArgs e)
+        {
+            DeleteConnection(e.Node.Uri.ToString());
+            if (sender is IBox box)
+            {
+                box.ConnectionGoesDown -= ConnectionWentDownHandler;
+                AddToReconnectingPool(e.Node.Uri.ToString(), box);
+            }
+        }
+        
+        private void ConnectionWentUpHandler(object sender, ConnectionWentUpEventArgs e)
+        {
+            if (sender is ConnectionReconnector reconnector)
+            {
+                RemoveFromReconnectingPool(e.ConnectionKey);
+                AddConnection(e.ConnectionKey, e.Box);
+                e.Box.ConnectionGoesDown += ConnectionWentDownHandler;
+                reconnector.Dispose();
+            }
+        }
+
+        private readonly Dictionary<string, ConnectionReconnector> _reconnectingPool = new Dictionary<string, ConnectionReconnector>();
+        private readonly ReaderWriterLockSlim _reconnectingPoolLock = new ReaderWriterLockSlim();
+        
+        private void AddToReconnectingPool(string key, IBox box)
+        {
+            _reconnectingPoolLock.EnterWriteLock();
+            try
+            {
+                if (!_reconnectingPool.ContainsKey(key))
+                {
+                    var reconnector = new ConnectionReconnector(box, key, _poolOptions);
+                    reconnector.ConnectionGoesUp += ConnectionWentUpHandler;
+                    reconnector.SetupReconnection();
+                    _reconnectingPool[key] = reconnector;
+                }
+            }
+            finally
+            {
+                _reconnectingPoolLock.ExitWriteLock();
+            }
+        }
+
+        private void RemoveFromReconnectingPool(string key)
+        {
+            _reconnectingPoolLock.EnterWriteLock();
+            try
+            {
+                _reconnectingPool.Remove(key);
+            }
+            finally
+            {
+                _reconnectingPoolLock.ExitWriteLock();
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"Pool of {_anyPool.GetAll().Length} instances. " +
+                   $"rw=[{string.Join(" ", _rwPool.GetAll().Select(i => i.Info.Uuid))}] " +
+                   $"ro=[{string.Join(" ", _roPool.GetAll().Select(i => i.Info.Uuid))}]";
+        }
+    }
+}

--- a/src/progaudi.tarantool/Pool/ConnectionReconnector.cs
+++ b/src/progaudi.tarantool/Pool/ConnectionReconnector.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using ProGaudi.Tarantool.Client.Core;
+using ProGaudi.Tarantool.Client.Model;
+
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    internal class ConnectionReconnector
+    {
+        private Timer _timer;
+        private int _disposing;
+        private int _attempts;
+        private readonly ConnectionPoolOptions _poolOptions;
+        private readonly IBox _box;
+        private readonly string _key;
+        
+        public ConnectionReconnector(IBox box, string key, ConnectionPoolOptions poolOptions)
+        {
+            _box = box;
+            _key = key;
+            _poolOptions = poolOptions;
+        }
+
+        public void SetupReconnection()
+        {
+            _timer = new Timer(_ => ReconnectAttempt(), null, _poolOptions.ReconnectIntervalInSeconds * 1000, Timeout.Infinite);
+        }
+        
+        public event EventHandler<ConnectionWentUpEventArgs> ConnectionGoesUp;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposing, 1) > 0)
+            {
+                return;
+            }
+
+            Interlocked.Exchange(ref _timer, null)?.Dispose();
+        }
+        
+        private void ReconnectAttempt()
+        {
+            try
+            {
+                _attempts++;
+                _box.Connect().GetAwaiter().GetResult();
+                if (_box.IsConnected)
+                {
+                    OnConnectionGoesUp(new ConnectionWentUpEventArgs { Box = _box, ConnectionKey = _key });
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+            finally
+            {
+                if (_disposing == 0)
+                {
+                    _timer?.Change(GetReconnectIntervalInMilliseconds(), Timeout.Infinite);
+                }
+            }
+        }
+
+        private void OnConnectionGoesUp(ConnectionWentUpEventArgs e)
+        {
+            var handler = ConnectionGoesUp;
+            handler?.Invoke(this, e);
+        }
+
+        private int GetReconnectIntervalInMilliseconds()
+        {
+            var coef = _attempts <= 10 ? _attempts : 10;
+            return _poolOptions.ReconnectIntervalInSeconds * coef * 1000;
+        }
+    }
+}

--- a/src/progaudi.tarantool/Pool/IBoxFactory.cs
+++ b/src/progaudi.tarantool/Pool/IBoxFactory.cs
@@ -1,0 +1,9 @@
+using ProGaudi.Tarantool.Client.Model;
+
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    public interface IBoxFactory
+    {
+        IBox Create(TarantoolNode node);
+    }
+}

--- a/src/progaudi.tarantool/Pool/IConnectionPool.cs
+++ b/src/progaudi.tarantool/Pool/IConnectionPool.cs
@@ -1,0 +1,46 @@
+using System.Threading.Tasks;
+using ProGaudi.Tarantool.Client.Model;
+using ProGaudi.Tarantool.Client.Model.Requests;
+using ProGaudi.Tarantool.Client.Model.Responses;
+using ProGaudi.Tarantool.Client.Model.UpdateOperations;
+
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    public interface IConnectionPool
+    {
+        Task Call(string functionName, RequestMode mode);
+
+        Task Call<TTuple>(string functionName, TTuple parameters, RequestMode mode);
+
+        Task<DataResponse<TResponse[]>> Call<TResponse>(string functionName, RequestMode mode);
+
+        Task<DataResponse<TResponse[]>> Call<TTuple, TResponse>(string functionName, TTuple parameters, RequestMode mode);
+
+        Task<DataResponse<TResponse[]>> Eval<TTuple, TResponse>(string expression, TTuple parameters, RequestMode mode);
+
+        Task<DataResponse<TResponse[]>> Eval<TResponse>(string expression, RequestMode mode);
+
+        Task<DataResponse> ExecuteSql(string query, RequestMode mode, params SqlParameter[] parameters);
+
+        Task<DataResponse<TResponse[]>> ExecuteSql<TResponse>(string query, RequestMode mode, params SqlParameter[] parameters);
+
+        Task<DataResponse<TTuple[]>> Insert<TTuple>(uint spaceId, TTuple tuple, RequestMode mode = RequestMode.Rw);
+
+        Task<DataResponse<TTuple[]>> Select<TKey, TTuple>(uint spaceId, TKey selectKey, RequestMode mode = RequestMode.Any);
+
+        Task<TTuple> Get<TKey, TTuple>(uint spaceId, TKey key, RequestMode mode = RequestMode.Any);
+
+        Task<DataResponse<TTuple[]>> Replace<TTuple>(uint spaceId, TTuple tuple, RequestMode mode = RequestMode.Rw);
+
+        Task<DataResponse<TTuple[]>> Update<TKey, TTuple>(uint spaceId, TKey key, UpdateOperation[] updateOperations,
+            RequestMode mode = RequestMode.Rw);
+
+        Task Upsert<TTuple>(uint spaceId, TTuple tuple, UpdateOperation[] updateOperations, RequestMode mode = RequestMode.Rw);
+
+        Task<DataResponse<TTuple[]>> Delete<TKey, TTuple>(uint spaceId, TKey key, RequestMode mode = RequestMode.Rw);
+        
+        Task Do<TRequest>(TRequest request, RequestMode mode) where TRequest : IRequest;
+
+        Task<DataResponse<TResponse[]>> Do<TRequest, TResponse>(TRequest request, RequestMode mode) where TRequest : IRequest;
+    }
+}

--- a/src/progaudi.tarantool/Pool/IPoolStrategy.cs
+++ b/src/progaudi.tarantool/Pool/IPoolStrategy.cs
@@ -1,0 +1,13 @@
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    internal interface IPoolStrategy<in TKey, TObj> 
+        where TObj : class
+    {
+        TObj GetNext();
+        TObj GetByKey(TKey key);
+        TObj[] GetAll();
+        void Add(TKey key, TObj conn);
+        TObj DeleteByKey(TKey key);
+        bool IsEmpty();
+    }
+}

--- a/src/progaudi.tarantool/Pool/ITarantoolNodesSource.cs
+++ b/src/progaudi.tarantool/Pool/ITarantoolNodesSource.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ProGaudi.Tarantool.Client.Model;
+
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    public interface ITarantoolNodesSource
+    {
+        Task<IList<TarantoolNode>> GetNodes();
+    }
+}

--- a/src/progaudi.tarantool/Pool/NoHealthyNodeException.cs
+++ b/src/progaudi.tarantool/Pool/NoHealthyNodeException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    public class NoHealthyNodeException : Exception
+    {
+        public NoHealthyNodeException() : base("There is no healthy node for current request")
+        {
+            
+        }
+    }
+}

--- a/src/progaudi.tarantool/Pool/PoolStatus.cs
+++ b/src/progaudi.tarantool/Pool/PoolStatus.cs
@@ -1,0 +1,9 @@
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    public enum PoolStatus
+    {
+        Unknown,
+        Connected,
+        Closed
+    }
+}

--- a/src/progaudi.tarantool/Pool/PooledBoxFactory.cs
+++ b/src/progaudi.tarantool/Pool/PooledBoxFactory.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using ProGaudi.Tarantool.Client.Model;
+
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    public class PooledBoxFactory : IBoxFactory
+    {
+        private readonly ClientOptions _clientOptions;
+        
+        public PooledBoxFactory(ClientOptions clientOptions)
+        {
+            _clientOptions = clientOptions;
+        }
+
+        public IBox Create(TarantoolNode node)
+        {
+            var nodeConnOptions = new ConnectionOptions
+            {
+                WriteStreamBufferSize = _clientOptions.ConnectionOptions.WriteStreamBufferSize,
+                MinRequestsWithThrottle = _clientOptions.ConnectionOptions.MinRequestsWithThrottle,
+                MaxRequestsInBatch = _clientOptions.ConnectionOptions.MaxRequestsInBatch,
+                WriteThrottlePeriodInMs = _clientOptions.ConnectionOptions.WriteThrottlePeriodInMs,
+                ReadStreamBufferSize = _clientOptions.ConnectionOptions.ReadStreamBufferSize,
+                WriteNetworkTimeout = _clientOptions.ConnectionOptions.WriteNetworkTimeout,
+                ReadNetworkTimeout = _clientOptions.ConnectionOptions.ReadNetworkTimeout,
+                PingCheckInterval = _clientOptions.ConnectionOptions.PingCheckInterval,
+                PingCheckTimeout = _clientOptions.ConnectionOptions.PingCheckTimeout,
+                ReadSchemaOnConnect = true,
+                ReadBoxInfoOnConnect = true,
+                Nodes = new List<TarantoolNode> { node }
+            };
+
+            var nodeBoxOptions =
+                new ClientOptions(nodeConnOptions, _clientOptions.LogWriter, _clientOptions.MsgPackContext);
+            return new Box(nodeBoxOptions);
+        }
+    }
+}

--- a/src/progaudi.tarantool/Pool/RequestMode.cs
+++ b/src/progaudi.tarantool/Pool/RequestMode.cs
@@ -1,0 +1,11 @@
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    public enum RequestMode
+    {
+        Any,
+        Rw,
+        Ro,
+        PreferRw,
+        PreferRo
+    }
+}

--- a/src/progaudi.tarantool/Pool/RoundRobinPool.cs
+++ b/src/progaudi.tarantool/Pool/RoundRobinPool.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    internal class RoundRobinPool<TKey, TObj> : IPoolStrategy<TKey, TObj>
+        where TObj : class
+    {
+        private readonly ReaderWriterLockSlim _lock;
+        private readonly List<TObj> _pool;
+        private readonly Dictionary<TKey, int> _indexByAddr;
+        private int _current;
+
+        public RoundRobinPool()
+        {
+            _lock = new ReaderWriterLockSlim();
+            _pool = new List<TObj>();
+            _indexByAddr = new Dictionary<TKey, int>();
+            _current = 0;
+        }
+
+        public TObj GetNext()
+        {
+            _lock.EnterReadLock();
+            try
+            {
+                if (_pool.Count == 0)
+                {
+                    return null;
+                }
+                
+                var updatedCurrentIndex = Interlocked.Increment(ref _current);
+                var nextIndex = (updatedCurrentIndex - 1) % _pool.Count;
+
+                return _pool[nextIndex];
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public TObj GetByKey(TKey key)
+        {
+            _lock.EnterReadLock();
+            try
+            {
+                return !_indexByAddr.ContainsKey(key) ? 
+                    null : 
+                    _pool[_indexByAddr[key]];
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public TObj[] GetAll()
+        {
+            _lock.EnterReadLock();
+            try
+            {
+                var result = new TObj[_pool.Count];
+                _pool.CopyTo(result, 0);
+                return result;
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public void Add(TKey key, TObj obj)
+        {
+            _lock.EnterWriteLock();
+            try
+            {
+                if (_indexByAddr.TryGetValue(key, out var existedIndex))
+                {
+                    _pool[existedIndex] = obj;
+                }
+                else
+                {
+                    _pool.Add(obj);
+                    _indexByAddr[key] = _pool.Count - 1;
+                }
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        public TObj DeleteByKey(TKey key)
+        {
+            _lock.EnterWriteLock();
+            try
+            {
+                if (_pool.Count == 0)
+                {
+                    return null;
+                }
+
+                if (!_indexByAddr.TryGetValue(key, out var index))
+                {
+                    return null;
+                }
+
+                _indexByAddr.Remove(key);
+
+                var obj = _pool[index];
+                _pool.RemoveAt(index);
+
+                foreach (var k in _indexByAddr.Keys.ToList())
+                {
+                    if (_indexByAddr[k] > index)
+                    {
+                        _indexByAddr[k] -= 1;
+                    }
+                }
+
+                return obj;
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        public bool IsEmpty()
+        {
+            return _pool.Count == 0;
+        }
+
+        ~RoundRobinPool()
+        {
+            _lock?.Dispose();
+        }
+    }
+}

--- a/src/progaudi.tarantool/Pool/TarantoolNodesConfigSource.cs
+++ b/src/progaudi.tarantool/Pool/TarantoolNodesConfigSource.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ProGaudi.Tarantool.Client.Model;
+
+namespace ProGaudi.Tarantool.Client.Pool
+{
+    public class TarantoolNodesConfigSource : ITarantoolNodesSource
+    {
+        private readonly ClientOptions _clientOptions;
+        
+        public TarantoolNodesConfigSource(ClientOptions clientOptions)
+        {
+            _clientOptions = clientOptions;
+        }
+
+        public async Task<IList<TarantoolNode>> GetNodes()
+        {
+            return await Task.FromResult(_clientOptions.ConnectionOptions.Nodes);
+        }
+    }
+}

--- a/src/progaudi.tarantool/Schema.cs
+++ b/src/progaudi.tarantool/Schema.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ProGaudi.Tarantool.Client.Core;
 using ProGaudi.Tarantool.Client.Model.Enums;
 using ProGaudi.Tarantool.Client.Model.Requests;
 using ProGaudi.Tarantool.Client.Utils;

--- a/src/progaudi.tarantool/Space.cs
+++ b/src/progaudi.tarantool/Space.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
+using ProGaudi.Tarantool.Client.Core;
 using ProGaudi.Tarantool.Client.Model;
 using ProGaudi.Tarantool.Client.Model.Enums;
 using ProGaudi.Tarantool.Client.Model.Requests;

--- a/src/progaudi.tarantool/progaudi.tarantool.csproj
+++ b/src/progaudi.tarantool/progaudi.tarantool.csproj
@@ -37,6 +37,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="progaudi.tarantool.tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="T4Templates\TarantoolTuples.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>TarantoolTuples.cs</LastGenOutput>
@@ -82,10 +86,6 @@
       <DependentUpon>ValueTupleConverters.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <DefineConstants>$(DefineConstants);PROGAUDI_NETCORE</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\"/>

--- a/src/tests/progaudi.tarantool.integration.tests/Pool/ConnectionPoolTests.cs
+++ b/src/tests/progaudi.tarantool.integration.tests/Pool/ConnectionPoolTests.cs
@@ -1,0 +1,200 @@
+using Moq;
+using NUnit.Framework;
+using ProGaudi.Tarantool.Client.Model;
+using ProGaudi.Tarantool.Client.Pool;
+using progaudi.tarantool.integration.tests.Pool.Mocks;
+
+namespace progaudi.tarantool.integration.tests.Pool;
+
+[TestFixture]
+public class ConnectionPoolTests
+{
+    [Test]
+    public async Task PoolWithSingleInstance_Call_WorksCorrectly()
+    {
+        // Arrange
+        var nodes = new List<TarantoolNodeMockInfo>
+        {
+            new() { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false }
+        };
+        var boxEventRegistrator = new MockBoxEventRegistrator();
+        var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+        var boxEvents = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+        
+        // Act
+        await pool.Call("do_something", RequestMode.Any);
+
+        // Assert
+        Assert.AreEqual(PoolStatus.Connected, pool.Status);
+        Assert.AreEqual(1, boxEvents.Count);
+        Assert.AreEqual("Call", boxEvents[0]);
+    }
+
+    [TestCase(RequestMode.Any, 2, 1, 1)]
+    [TestCase(RequestMode.Ro, 2, 0, 2)]
+    [TestCase(RequestMode.Rw, 2, 2, 0)]
+    [TestCase(RequestMode.PreferRo, 2, 0, 2)]
+    [TestCase(RequestMode.PreferRw, 2, 2, 0)]
+    public async Task PoolWithRoAndRw_AllRequestModes_WorksCorrectly(RequestMode requestMode, 
+        int overallCalls, int expectedRwCalls, int expectedRoCalls)
+    {
+        // Arrange
+        var nodes = new List<TarantoolNodeMockInfo>
+        {
+            new() { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false },
+            new() { Alive = true, Uri = "host:12346", Uuid = Guid.NewGuid(), ReadOnly = true }
+        };
+        var boxEventRegistrator = new MockBoxEventRegistrator();
+        var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+
+        var rwEvents = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+        var roEvents = boxEventRegistrator.GetInstanceEvents(nodes[1].Uuid);
+        
+        // Act 
+        foreach (var i in Enumerable.Range(0, overallCalls))
+        {
+            await pool.Call($"do_something_{i}", requestMode);
+        }
+
+        // Assert
+        Assert.AreEqual(expectedRwCalls, rwEvents.Count);
+        Assert.AreEqual(expectedRoCalls, roEvents.Count);
+    }
+
+    [Test]
+    public async Task PoolWithRo_RwAndPreferRw_WorksCorrectly()
+    {
+        // Arrange
+        var nodes = new List<TarantoolNodeMockInfo>
+        {
+            new() { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = true }
+        };
+        var boxEventRegistrator = new MockBoxEventRegistrator();
+        var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+        var events = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+        
+        //Act and Assert
+        await pool.Call("do_something", RequestMode.PreferRw);
+        Assert.AreEqual(1, events.Count);
+        
+        Assert.ThrowsAsync<NoHealthyNodeException>(
+            async () => await pool.Call("do_something", RequestMode.Rw));
+        Assert.AreEqual(1, events.Count);
+    }
+    
+    [Test]
+    public async Task PoolWithRw_RoAndPreferRo_WorksCorrectly()
+    {
+        // Arrange
+        var nodes = new List<TarantoolNodeMockInfo>
+        {
+            new() { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false }
+        };
+        var boxEventRegistrator = new MockBoxEventRegistrator();
+        var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+        var events = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+        
+        //Act and Assert
+        await pool.Call("do_something", RequestMode.PreferRo);
+        Assert.AreEqual(1, events.Count);
+        
+        Assert.ThrowsAsync<NoHealthyNodeException>(
+            async () => await pool.Call("do_something", RequestMode.Ro));
+        Assert.AreEqual(1, events.Count);
+    }
+
+    [Test]
+    public void DeadPool_WorksAsExpected()
+    {
+        // Arrange
+        var nodes = new List<TarantoolNodeMockInfo>
+        {
+            new() { Alive = false, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false },
+            new() { Alive = false, Uri = "host:12346", Uuid = Guid.NewGuid(), ReadOnly = true }
+        };
+        var boxEventRegistrator = new MockBoxEventRegistrator();
+        var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+
+        // Act and Assert
+        Assert.AreEqual(PoolStatus.Closed, pool.Status);
+        Assert.ThrowsAsync<NoHealthyNodeException>(
+            async () => await pool.Call("do_something", RequestMode.Any));
+    }
+
+    [Test]
+    public async Task PoolWithNodeGoesDownAndUp_WorksCorrectly()
+    {
+        // Arrange
+        var nodes = new List<TarantoolNodeMockInfo>
+        {
+            new() { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false }
+        };
+        var boxEventRegistrator = new MockBoxEventRegistrator();
+        var (pool, boxFactory, tarantoolNodes) = CreateConnectionPoolWithMocks(
+            nodes, boxEventRegistrator, new ConnectionPoolOptions {ReconnectIntervalInSeconds = 1});
+        var events = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+        var box = boxFactory.GetBox(tarantoolNodes[nodes[0].Uri]);
+
+        //Act and Assert
+        await pool.Call("do_something", RequestMode.Any);
+        Assert.AreEqual(1, events.Count);// it works fine initially
+        
+        box.GoDown();
+        Assert.AreEqual(PoolStatus.Closed, pool.Status);
+        Assert.ThrowsAsync<NoHealthyNodeException>(
+            async () => await pool.Call("do_something", RequestMode.Any));
+        
+        box.GoUp();
+        Thread.Sleep(1100);//wait for reconnector does its job in background
+        
+        await pool.Call("do_something", RequestMode.Any);
+        Assert.AreEqual(2, events.Count);// it works fine in the end
+    }
+
+    private static BoxInfo CreateBoxInfo(Guid uuid, bool readOnly)
+    {
+        var mockedBoxInfo = new Mock<BoxInfo>();
+        mockedBoxInfo.SetupGet(b => b.Uuid).Returns(uuid);
+        mockedBoxInfo.SetupGet(b => b.ReadOnly).Returns(readOnly);
+        return mockedBoxInfo.Object;
+    }
+    
+    private static (ConnectionPool, MockBoxFactory, Dictionary<string, TarantoolNode>) CreateConnectionPoolWithMocks(
+        List<TarantoolNodeMockInfo> nodes,
+        MockBoxEventRegistrator boxEventRegistrator,
+        ConnectionPoolOptions connectionPoolOptions = null)
+    {
+        var tarantoolNodes = nodes.ToDictionary(
+            x => x.Uri, 
+            x => new TarantoolNode(x.Uri));
+        
+        var mockedNodeSource = new Mock<ITarantoolNodesSource>();
+        mockedNodeSource.Setup(s => s.GetNodes())
+            .ReturnsAsync(tarantoolNodes.Values.ToList());
+
+        var aliveMapping = nodes.ToDictionary(
+            mockInfo => tarantoolNodes[mockInfo.Uri],
+            mockInfo => mockInfo.Alive);
+        var boxInfoMapping = nodes.ToDictionary(
+            mockInfo => tarantoolNodes[mockInfo.Uri],
+            mockInfo => CreateBoxInfo(mockInfo.Uuid, mockInfo.ReadOnly));
+
+        var boxFactory = new MockBoxFactory(
+            aliveMapping,
+            boxInfoMapping,
+            boxEventRegistrator);
+        var pool = new ConnectionPool(connectionPoolOptions ?? new ConnectionPoolOptions(), 
+            mockedNodeSource.Object,
+            boxFactory);
+
+        return (pool, boxFactory, tarantoolNodes);
+    }
+
+    private class TarantoolNodeMockInfo
+    {
+        public string Uri { get; init; }
+        public Guid Uuid { get; init; }
+        public bool ReadOnly { get; init; }
+        public bool Alive { get; init; }
+    }
+}

--- a/src/tests/progaudi.tarantool.integration.tests/Pool/Mocks/MockBox.cs
+++ b/src/tests/progaudi.tarantool.integration.tests/Pool/Mocks/MockBox.cs
@@ -1,0 +1,167 @@
+using ProGaudi.Tarantool.Client;
+using ProGaudi.Tarantool.Client.Core;
+using ProGaudi.Tarantool.Client.Model;
+using ProGaudi.Tarantool.Client.Model.Requests;
+using ProGaudi.Tarantool.Client.Model.Responses;
+
+namespace progaudi.tarantool.integration.tests.Pool.Mocks;
+
+public class MockBox : IBox
+{
+    private bool _alive;
+    private readonly BoxInfo _boxInfo;
+    private readonly TarantoolNode _node;
+    private readonly MockBoxEventRegistrator _eventRegistrator;
+    private bool _isConnected = false;
+    private BoxInfo _currentBoxInfo;
+
+    public static string GET_CURRENT_INSTANCE_ID = "get_current_instance_id";
+    
+    public MockBox(bool alive, BoxInfo boxInfo, TarantoolNode node, MockBoxEventRegistrator eventRegistrator)
+    {
+        _alive = alive;
+        _boxInfo = boxInfo;
+        _node = node;
+        _eventRegistrator = eventRegistrator;
+    }
+
+    public void GoDown()
+    {
+        _alive = false;
+        _isConnected = false;
+        ConnectionGoesDown?.Invoke(this, new ConnectionWentDownEventArgs(_node));
+    }
+    
+    public void GoUp()
+    {
+        _alive = true;
+    }
+    
+    public void Dispose()
+    {
+    }
+
+    public Task Connect()
+    {
+        if (_alive)
+        {
+            _isConnected = true;
+            _currentBoxInfo = _boxInfo;
+        }
+        else
+        {
+            _isConnected = false;
+            _currentBoxInfo = null;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public bool IsConnected => _isConnected;
+    public Metrics Metrics { get; }
+    public ISchema Schema { get; }
+    public BoxInfo Info => _currentBoxInfo;
+    public ISchema GetSchema()
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(GetSchema));
+        return null;
+    }
+
+    public Task ReloadSchema()
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(ReloadSchema));
+        return Task.CompletedTask;
+    }
+
+    public Task ReloadBoxInfo()
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(ReloadBoxInfo));
+        return Task.CompletedTask;
+    }
+
+    public Task Call_1_6(string functionName)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call_1_6));
+        return Task.CompletedTask;
+    }
+
+    public Task Call_1_6<TTuple>(string functionName, TTuple parameters)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call_1_6));
+        return Task.CompletedTask;
+    }
+
+    public Task<DataResponse<TResponse[]>> Call_1_6<TResponse>(string functionName)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call_1_6));
+        return Task.FromResult<DataResponse<TResponse[]>>(null);
+    }
+
+    public Task<DataResponse<TResponse[]>> Call_1_6<TTuple, TResponse>(string functionName, TTuple parameters)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call_1_6));
+        return Task.FromResult<DataResponse<TResponse[]>>(null);
+    }
+
+    public Task Call(string functionName)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call));
+        return Task.CompletedTask;
+    }
+
+    public Task Call<TTuple>(string functionName, TTuple parameters)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call));
+        return Task.CompletedTask;
+    }
+
+    public Task<DataResponse<TResponse[]>> Call<TResponse>(string functionName)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call));
+        return Task.FromResult<DataResponse<TResponse[]>>(null);
+    }
+
+    public Task<DataResponse<TResponse[]>> Call<TTuple, TResponse>(string functionName, TTuple parameters)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call));
+        return Task.FromResult<DataResponse<TResponse[]>>(null);
+    }
+
+    public Task<DataResponse<TResponse[]>> Eval<TTuple, TResponse>(string expression, TTuple parameters)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Eval));
+        return Task.FromResult<DataResponse<TResponse[]>>(null);
+    }
+
+    public Task<DataResponse<TResponse[]>> Eval<TResponse>(string expression)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Eval));
+        return Task.FromResult<DataResponse<TResponse[]>>(null);
+    }
+
+    public Task<DataResponse<TResponse[]>> ExecuteSql<TResponse>(string query, params SqlParameter[] parameters)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(ExecuteSql));
+        return Task.FromResult<DataResponse<TResponse[]>>(null);
+    }
+
+    public Task<DataResponse> ExecuteSql(string query, params SqlParameter[] parameters)
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(ExecuteSql));
+        return Task.FromResult<DataResponse>(null);
+    }
+
+    public Task Do<TRequest>(TRequest request) where TRequest : IRequest
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Do));
+        return Task.CompletedTask;
+    }
+
+    public Task<DataResponse<TResponse[]>> Do<TRequest, TResponse>(TRequest request) where TRequest : IRequest
+    {
+        _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Do));
+        return Task.FromResult<DataResponse<TResponse[]>>(null);
+    }
+
+    public event EventHandler<ConnectionWentDownEventArgs> ConnectionGoesDown;
+}

--- a/src/tests/progaudi.tarantool.integration.tests/Pool/Mocks/MockBoxEventRegistrator.cs
+++ b/src/tests/progaudi.tarantool.integration.tests/Pool/Mocks/MockBoxEventRegistrator.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+
+namespace progaudi.tarantool.integration.tests.Pool.Mocks;
+
+public class MockBoxEventRegistrator
+{
+    private readonly ConcurrentDictionary<Guid, List<string>> _registeredEvents;
+
+    public MockBoxEventRegistrator()
+    {
+        _registeredEvents = new ConcurrentDictionary<Guid, List<string>>();
+    }
+
+    public void RegisterBoxEvent(Guid instanceId, string eventName)
+    {
+        if (_registeredEvents.TryGetValue(instanceId, out var eventList))
+        {
+            eventList.Add(eventName);
+        }
+        else
+        {
+            _registeredEvents.TryAdd(instanceId, new List<string> { eventName });
+        }
+    }
+
+    public List<string> GetInstanceEvents(Guid instanceId)
+    {
+        if (_registeredEvents.TryGetValue(instanceId, out var res))
+        {
+            return res;
+        }
+
+        var newList = new List<string>();
+        _registeredEvents.TryAdd(instanceId, newList);
+        return newList;
+    }
+}

--- a/src/tests/progaudi.tarantool.integration.tests/Pool/Mocks/MockBoxFactory.cs
+++ b/src/tests/progaudi.tarantool.integration.tests/Pool/Mocks/MockBoxFactory.cs
@@ -1,0 +1,35 @@
+using ProGaudi.Tarantool.Client;
+using ProGaudi.Tarantool.Client.Model;
+using ProGaudi.Tarantool.Client.Pool;
+
+namespace progaudi.tarantool.integration.tests.Pool.Mocks;
+
+public class MockBoxFactory : IBoxFactory
+{
+    private readonly Dictionary<TarantoolNode, bool> _aliveMapping;
+    private readonly Dictionary<TarantoolNode, BoxInfo> _boxInfoMapping;
+    private readonly Dictionary<TarantoolNode, MockBox> _boxMapping;
+    private readonly MockBoxEventRegistrator _boxEventRegistrator;
+
+    public MockBoxFactory(Dictionary<TarantoolNode, bool> aliveMapping, 
+        Dictionary<TarantoolNode, BoxInfo> boxInfoMapping,
+        MockBoxEventRegistrator boxEventRegistrator)
+    {
+        _aliveMapping = aliveMapping;
+        _boxInfoMapping = boxInfoMapping;
+        _boxEventRegistrator = boxEventRegistrator;
+        _boxMapping = new Dictionary<TarantoolNode, MockBox>();
+    }
+
+    public IBox Create(TarantoolNode node)
+    {
+        var box = new MockBox(_aliveMapping[node], _boxInfoMapping[node], node, _boxEventRegistrator);
+        _boxMapping[node] = box;
+        return box;
+    }
+
+    public MockBox GetBox(TarantoolNode node)
+    {
+        return _boxMapping.TryGetValue(node, out var box) ? box : null;
+    }
+}

--- a/src/tests/progaudi.tarantool.integration.tests/Pool/RoundRobinPoolTests.cs
+++ b/src/tests/progaudi.tarantool.integration.tests/Pool/RoundRobinPoolTests.cs
@@ -1,0 +1,116 @@
+using NUnit.Framework;
+using ProGaudi.Tarantool.Client.Pool;
+
+namespace progaudi.tarantool.integration.tests.Pool;
+
+[TestFixture]
+public class RoundRobinPoolTests
+{
+    [Test]
+    public void AddAndDelete_WorksCorrectly()
+    {
+        // Arrange
+        var pool = new RoundRobinPool<string, string>();
+
+        var keys = new string[2] { "key1", "key2" };
+        var objs = new string[2] { "obj1", "obj2" };
+
+        // Act and Assert
+        foreach (var index in Enumerable.Range(0, keys.Length))
+        {
+            pool.Add(keys[index], objs[index]);
+        }
+
+        foreach (var index in Enumerable.Range(0, keys.Length))
+        {
+            var obj = pool.DeleteByKey(keys[index]);
+            Assert.AreEqual(objs[index], obj);
+        }
+        
+        Assert.True(pool.IsEmpty());
+    }
+    
+    [Test]
+    public void AddAndGetAll_WorksCorrectly()
+    {
+        // Arrange
+        var pool = new RoundRobinPool<string, string>();
+
+        var keys = new string[2] { "key1", "key2" };
+        var objs = new string[2] { "obj1", "obj2" };
+
+        // Act
+        foreach (var index in Enumerable.Range(0, keys.Length))
+        {
+            pool.Add(keys[index], objs[index]);
+        }
+        var poolObjects = pool.GetAll();
+        
+        // Assert
+        Assert.AreEqual(keys.Length, poolObjects.Length);
+        foreach (var index in Enumerable.Range(0, keys.Length))
+        {
+            Assert.AreEqual(poolObjects[index], objs[index]);
+        }
+    }
+    
+    [Test]
+    public void AddAndGetByKey_WorksCorrectly()
+    {
+        // Arrange
+        var pool = new RoundRobinPool<string, string>();
+
+        var keys = new string[2] { "key1", "key2" };
+        var objs = new string[2] { "obj1", "obj2" };
+
+        // Act
+        foreach (var index in Enumerable.Range(0, keys.Length))
+        {
+            pool.Add(keys[index], objs[index]);
+        }
+        
+        // Assert
+        foreach (var index in Enumerable.Range(0, keys.Length))
+        {
+            Assert.AreEqual(objs[index], pool.GetByKey(keys[index]));
+        }
+    }
+
+    [Test]
+    public void AddObjectsByDuplicateKey_WorksCorrectly()
+    {
+        // Arrange
+        var pool = new RoundRobinPool<string, string>();
+        
+        // Act
+        pool.Add("key", "obj1");
+        pool.Add("key", "obj2");
+        
+        // Assert
+        Assert.AreEqual("obj2", pool.DeleteByKey("key"));
+        Assert.True(pool.IsEmpty());
+        Assert.IsNull(pool.DeleteByKey("key"));
+    }
+
+    [Test]
+    public void AddAndGetNext_WorksCorrectly()
+    {
+        // Arrange
+        var pool = new RoundRobinPool<string, string>();
+
+        var keys = new string[2] { "key1", "key2" };
+        var objs = new string[2] { "obj1", "obj2" };
+        
+        foreach (var index in Enumerable.Range(0, keys.Length))
+        {
+            pool.Add(keys[index], objs[index]);
+        }
+
+        // Act and Assert
+        var expected = new string[6] { "obj1", "obj2", "obj1", "obj2", "obj1", "obj2" };
+        foreach (var i in Enumerable.Range(0, expected.Length))
+        {
+            Assert.AreEqual(expected[i], pool.GetNext());
+        }
+    }
+}

--- a/src/tests/progaudi.tarantool.integration.tests/progaudi.tarantool.integration.tests.csproj
+++ b/src/tests/progaudi.tarantool.integration.tests/progaudi.tarantool.integration.tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<PackageReference Include="Shouldly" Version="4.2.1" />
+    <ProjectReference Include="..\..\progaudi.tarantool\progaudi.tarantool.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/progaudi.tarantool.tests/Pool/ConnectionPoolTests.cs
+++ b/tests/progaudi.tarantool.tests/Pool/ConnectionPoolTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using ProGaudi.Tarantool.Client.Model;
+using ProGaudi.Tarantool.Client.Pool;
+using ProGaudi.Tarantool.Client.Tests.Pool.Mocks;
+using Xunit;
+using Shouldly;
+
+namespace ProGaudi.Tarantool.Client.Tests.Pool
+{
+    public class ConnectionPoolTests
+    {
+        [Fact]
+        public async Task PoolWithSingleInstance_Call_WorksCorrectly()
+        {
+            // Arrange
+            var nodes = new List<TarantoolNodeMockInfo>
+            {
+                new TarantoolNodeMockInfo { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false }
+            };
+            var boxEventRegistrator = new MockBoxEventRegistrator();
+            var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+            var boxEvents = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+            
+            // Act
+            await pool.Call("do_something", RequestMode.Any);
+
+            // Assert
+            Assert.Equal(PoolStatus.Connected, pool.Status);
+            boxEvents.Count.ShouldBe(1);
+            Assert.Equal("Call", boxEvents[0]);
+        }
+
+        [Theory]
+        [InlineData(RequestMode.Any, 2, 1, 1)]
+        [InlineData(RequestMode.Ro, 2, 0, 2)]
+        [InlineData(RequestMode.Rw, 2, 2, 0)]
+        [InlineData(RequestMode.PreferRo, 2, 0, 2)]
+        [InlineData(RequestMode.PreferRw, 2, 2, 0)]
+        public async Task PoolWithRoAndRw_AllRequestModes_WorksCorrectly(RequestMode requestMode, 
+            int overallCalls, int expectedRwCalls, int expectedRoCalls)
+        {
+            // Arrange
+            var nodes = new List<TarantoolNodeMockInfo>
+            {
+                new TarantoolNodeMockInfo { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false },
+                new TarantoolNodeMockInfo { Alive = true, Uri = "host:12346", Uuid = Guid.NewGuid(), ReadOnly = true }
+            };
+            var boxEventRegistrator = new MockBoxEventRegistrator();
+            var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+
+            var rwEvents = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+            var roEvents = boxEventRegistrator.GetInstanceEvents(nodes[1].Uuid);
+            
+            // Act 
+            foreach (var i in Enumerable.Range(0, overallCalls))
+            {
+                await pool.Call($"do_something_{i}", requestMode);
+            }
+
+            // Assert
+            rwEvents.Count.ShouldBe(expectedRwCalls);
+            roEvents.Count.ShouldBe(expectedRoCalls);
+        }
+
+        [Fact]
+        public async Task PoolWithRo_RwAndPreferRw_WorksCorrectly()
+        {
+            // Arrange
+            var nodes = new List<TarantoolNodeMockInfo>
+            {
+                new TarantoolNodeMockInfo { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = true }
+            };
+            var boxEventRegistrator = new MockBoxEventRegistrator();
+            var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+            var events = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+            
+            //Act and Assert
+            await pool.Call("do_something", RequestMode.PreferRw);
+            events.Count.ShouldBe(1);
+            
+            await Assert.ThrowsAsync<NoHealthyNodeException>(
+                async () => await pool.Call("do_something", RequestMode.Rw));
+            events.Count.ShouldBe(1);
+        }
+        
+        [Fact]
+        public async Task PoolWithRw_RoAndPreferRo_WorksCorrectly()
+        {
+            // Arrange
+            var nodes = new List<TarantoolNodeMockInfo>
+            {
+                new TarantoolNodeMockInfo { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false }
+            };
+            var boxEventRegistrator = new MockBoxEventRegistrator();
+            var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+            var events = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+            
+            //Act and Assert
+            await pool.Call("do_something", RequestMode.PreferRo);
+            events.Count.ShouldBe(1);
+            
+            await Assert.ThrowsAsync<NoHealthyNodeException>(
+                async () => await pool.Call("do_something", RequestMode.Ro));
+            events.Count.ShouldBe(1);
+        }
+
+        [Fact]
+        public async Task DeadPool_WorksAsExpected()
+        {
+            // Arrange
+            var nodes = new List<TarantoolNodeMockInfo>
+            {
+                new TarantoolNodeMockInfo { Alive = false, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false },
+                new TarantoolNodeMockInfo { Alive = false, Uri = "host:12346", Uuid = Guid.NewGuid(), ReadOnly = true }
+            };
+            var boxEventRegistrator = new MockBoxEventRegistrator();
+            var (pool, _, _) = CreateConnectionPoolWithMocks(nodes, boxEventRegistrator);
+
+            // Act and Assert
+            Assert.Equal(PoolStatus.Closed, pool.Status);
+            await Assert.ThrowsAsync<NoHealthyNodeException>(
+                async () => await pool.Call("do_something", RequestMode.Any));
+        }
+
+        [Fact]
+        public async Task PoolWithNodeGoesDownAndUp_WorksCorrectly()
+        {
+            // Arrange
+            var nodes = new List<TarantoolNodeMockInfo>
+            {
+                new TarantoolNodeMockInfo { Alive = true, Uri = "host:12345", Uuid = Guid.NewGuid(), ReadOnly = false }
+            };
+            var boxEventRegistrator = new MockBoxEventRegistrator();
+            var (pool, boxFactory, tarantoolNodes) = CreateConnectionPoolWithMocks(
+                nodes, boxEventRegistrator, new ConnectionPoolOptions {ReconnectIntervalInSeconds = 1});
+            var events = boxEventRegistrator.GetInstanceEvents(nodes[0].Uuid);
+            var box = boxFactory.GetBox(tarantoolNodes[nodes[0].Uri]);
+
+            //Act and Assert
+            await pool.Call("do_something", RequestMode.Any);
+            events.Count.ShouldBe(1);// it works fine initially
+            
+            box.GoDown();
+            Assert.Equal(PoolStatus.Closed, pool.Status);
+            await Assert.ThrowsAsync<NoHealthyNodeException>(
+                async () => await pool.Call("do_something", RequestMode.Any));
+            
+            box.GoUp();
+            Thread.Sleep(1100);//wait for reconnector does its job in background
+            
+            await pool.Call("do_something", RequestMode.Any);
+            events.Count.ShouldBe(2);// it works fine in the end
+        }
+
+        private static BoxInfo CreateBoxInfo(Guid uuid, bool readOnly)
+        {
+            var mockedBoxInfo = new Mock<BoxInfo>();
+            mockedBoxInfo.SetupGet(b => b.Uuid).Returns(uuid);
+            mockedBoxInfo.SetupGet(b => b.ReadOnly).Returns(readOnly);
+            return mockedBoxInfo.Object;
+        }
+        
+        private static (ConnectionPool, MockBoxFactory, Dictionary<string, TarantoolNode>) CreateConnectionPoolWithMocks(
+            List<TarantoolNodeMockInfo> nodes,
+            MockBoxEventRegistrator boxEventRegistrator,
+            ConnectionPoolOptions connectionPoolOptions = null)
+        {
+            var tarantoolNodes = nodes.ToDictionary(
+                x => x.Uri, 
+                x => new TarantoolNode(x.Uri));
+            
+            var mockedNodeSource = new Mock<ITarantoolNodesSource>();
+            mockedNodeSource.Setup(s => s.GetNodes())
+                .ReturnsAsync(tarantoolNodes.Values.ToList());
+
+            var aliveMapping = nodes.ToDictionary(
+                mockInfo => tarantoolNodes[mockInfo.Uri],
+                mockInfo => mockInfo.Alive);
+            var boxInfoMapping = nodes.ToDictionary(
+                mockInfo => tarantoolNodes[mockInfo.Uri],
+                mockInfo => CreateBoxInfo(mockInfo.Uuid, mockInfo.ReadOnly));
+
+            var boxFactory = new MockBoxFactory(
+                aliveMapping,
+                boxInfoMapping,
+                boxEventRegistrator);
+            var pool = new ConnectionPool(connectionPoolOptions ?? new ConnectionPoolOptions(), 
+                mockedNodeSource.Object,
+                boxFactory);
+
+            return (pool, boxFactory, tarantoolNodes);
+        }
+
+        private class TarantoolNodeMockInfo
+        {
+            public string Uri { get; set; }
+            public Guid Uuid { get; set; }
+            public bool ReadOnly { get; set; }
+            public bool Alive { get; set; }
+        }
+    }
+}

--- a/tests/progaudi.tarantool.tests/Pool/Mocks/MockBox.cs
+++ b/tests/progaudi.tarantool.tests/Pool/Mocks/MockBox.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Threading.Tasks;
+using ProGaudi.Tarantool.Client.Core;
+using ProGaudi.Tarantool.Client.Model;
+using ProGaudi.Tarantool.Client.Model.Requests;
+using ProGaudi.Tarantool.Client.Model.Responses;
+
+namespace ProGaudi.Tarantool.Client.Tests.Pool.Mocks
+{
+    public class MockBox : IBox
+    {
+        private bool _alive;
+        private readonly BoxInfo _boxInfo;
+        private readonly TarantoolNode _node;
+        private readonly MockBoxEventRegistrator _eventRegistrator;
+        private bool _isConnected = false;
+        private BoxInfo _currentBoxInfo;
+
+        public static string GET_CURRENT_INSTANCE_ID = "get_current_instance_id";
+
+        public MockBox(bool alive, BoxInfo boxInfo, TarantoolNode node, MockBoxEventRegistrator eventRegistrator)
+        {
+            _alive = alive;
+            _boxInfo = boxInfo;
+            _node = node;
+            _eventRegistrator = eventRegistrator;
+        }
+
+        public void GoDown()
+        {
+            _alive = false;
+            _isConnected = false;
+            ConnectionGoesDown?.Invoke(this, new ConnectionWentDownEventArgs(_node));
+        }
+
+        public void GoUp()
+        {
+            _alive = true;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public Task Connect()
+        {
+            if (_alive)
+            {
+                _isConnected = true;
+                _currentBoxInfo = _boxInfo;
+            }
+            else
+            {
+                _isConnected = false;
+                _currentBoxInfo = null;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public bool IsConnected => _isConnected;
+        public Metrics Metrics { get; }
+        public ISchema Schema { get; }
+        public BoxInfo Info => _currentBoxInfo;
+
+        public ISchema GetSchema()
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(GetSchema));
+            return null;
+        }
+
+        public Task ReloadSchema()
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(ReloadSchema));
+            return Task.CompletedTask;
+        }
+
+        public Task ReloadBoxInfo()
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(ReloadBoxInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task Call_1_6(string functionName)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call_1_6));
+            return Task.CompletedTask;
+        }
+
+        public Task Call_1_6<TTuple>(string functionName, TTuple parameters)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call_1_6));
+            return Task.CompletedTask;
+        }
+
+        public Task<DataResponse<TResponse[]>> Call_1_6<TResponse>(string functionName)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call_1_6));
+            return Task.FromResult<DataResponse<TResponse[]>>(null);
+        }
+
+        public Task<DataResponse<TResponse[]>> Call_1_6<TTuple, TResponse>(string functionName, TTuple parameters)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call_1_6));
+            return Task.FromResult<DataResponse<TResponse[]>>(null);
+        }
+
+        public Task Call(string functionName)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call));
+            return Task.CompletedTask;
+        }
+
+        public Task Call<TTuple>(string functionName, TTuple parameters)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call));
+            return Task.CompletedTask;
+        }
+
+        public Task<DataResponse<TResponse[]>> Call<TResponse>(string functionName)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call));
+            return Task.FromResult<DataResponse<TResponse[]>>(null);
+        }
+
+        public Task<DataResponse<TResponse[]>> Call<TTuple, TResponse>(string functionName, TTuple parameters)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Call));
+            return Task.FromResult<DataResponse<TResponse[]>>(null);
+        }
+
+        public Task<DataResponse<TResponse[]>> Eval<TTuple, TResponse>(string expression, TTuple parameters)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Eval));
+            return Task.FromResult<DataResponse<TResponse[]>>(null);
+        }
+
+        public Task<DataResponse<TResponse[]>> Eval<TResponse>(string expression)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Eval));
+            return Task.FromResult<DataResponse<TResponse[]>>(null);
+        }
+
+        public Task<DataResponse<TResponse[]>> ExecuteSql<TResponse>(string query, params SqlParameter[] parameters)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(ExecuteSql));
+            return Task.FromResult<DataResponse<TResponse[]>>(null);
+        }
+
+        public Task<DataResponse> ExecuteSql(string query, params SqlParameter[] parameters)
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(ExecuteSql));
+            return Task.FromResult<DataResponse>(null);
+        }
+
+        public Task Do<TRequest>(TRequest request) where TRequest : IRequest
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Do));
+            return Task.CompletedTask;
+        }
+
+        public Task<DataResponse<TResponse[]>> Do<TRequest, TResponse>(TRequest request) where TRequest : IRequest
+        {
+            _eventRegistrator.RegisterBoxEvent(_currentBoxInfo.Uuid, nameof(Do));
+            return Task.FromResult<DataResponse<TResponse[]>>(null);
+        }
+
+        public event EventHandler<ConnectionWentDownEventArgs> ConnectionGoesDown;
+    }
+}

--- a/tests/progaudi.tarantool.tests/Pool/Mocks/MockBoxEventRegistrator.cs
+++ b/tests/progaudi.tarantool.tests/Pool/Mocks/MockBoxEventRegistrator.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace ProGaudi.Tarantool.Client.Tests.Pool.Mocks
+{
+    public class MockBoxEventRegistrator
+    {
+        private readonly ConcurrentDictionary<Guid, List<string>> _registeredEvents;
+
+        public MockBoxEventRegistrator()
+        {
+            _registeredEvents = new ConcurrentDictionary<Guid, List<string>>();
+        }
+
+        public void RegisterBoxEvent(Guid instanceId, string eventName)
+        {
+            if (_registeredEvents.TryGetValue(instanceId, out var eventList))
+            {
+                eventList.Add(eventName);
+            }
+            else
+            {
+                _registeredEvents.TryAdd(instanceId, new List<string> { eventName });
+            }
+        }
+
+        public List<string> GetInstanceEvents(Guid instanceId)
+        {
+            if (_registeredEvents.TryGetValue(instanceId, out var res))
+            {
+                return res;
+            }
+
+            var newList = new List<string>();
+            _registeredEvents.TryAdd(instanceId, newList);
+            return newList;
+        }
+    }
+}

--- a/tests/progaudi.tarantool.tests/Pool/Mocks/MockBoxFactory.cs
+++ b/tests/progaudi.tarantool.tests/Pool/Mocks/MockBoxFactory.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using ProGaudi.Tarantool.Client.Model;
+using ProGaudi.Tarantool.Client.Pool;
+
+namespace ProGaudi.Tarantool.Client.Tests.Pool.Mocks
+{
+    public class MockBoxFactory : IBoxFactory
+    {
+        private readonly Dictionary<TarantoolNode, bool> _aliveMapping;
+        private readonly Dictionary<TarantoolNode, BoxInfo> _boxInfoMapping;
+        private readonly Dictionary<TarantoolNode, MockBox> _boxMapping;
+        private readonly MockBoxEventRegistrator _boxEventRegistrator;
+
+        public MockBoxFactory(Dictionary<TarantoolNode, bool> aliveMapping, 
+            Dictionary<TarantoolNode, BoxInfo> boxInfoMapping,
+            MockBoxEventRegistrator boxEventRegistrator)
+        {
+            _aliveMapping = aliveMapping;
+            _boxInfoMapping = boxInfoMapping;
+            _boxEventRegistrator = boxEventRegistrator;
+            _boxMapping = new Dictionary<TarantoolNode, MockBox>();
+        }
+
+        public IBox Create(TarantoolNode node)
+        {
+            var box = new MockBox(_aliveMapping[node], _boxInfoMapping[node], node, _boxEventRegistrator);
+            _boxMapping[node] = box;
+            return box;
+        }
+
+        public MockBox GetBox(TarantoolNode node)
+        {
+            return _boxMapping.TryGetValue(node, out var box) ? box : null;
+        }
+    }
+}

--- a/tests/progaudi.tarantool.tests/Pool/RoundRobinPoolTests.cs
+++ b/tests/progaudi.tarantool.tests/Pool/RoundRobinPoolTests.cs
@@ -1,0 +1,118 @@
+using System.Linq;
+using ProGaudi.Tarantool.Client.Pool;
+using Xunit;
+
+namespace ProGaudi.Tarantool.Client.Tests.Pool
+{
+    public class RoundRobinPoolTests
+    {
+        [Fact]
+        public void AddAndDelete_WorksCorrectly()
+        {
+            // Arrange
+            var pool = new RoundRobinPool<string, string>();
+
+            var keys = new string[2] { "key1", "key2" };
+            var objs = new string[2] { "obj1", "obj2" };
+
+            // Act and Assert
+            foreach (var index in Enumerable.Range(0, keys.Length))
+            {
+                pool.Add(keys[index], objs[index]);
+            }
+
+            foreach (var index in Enumerable.Range(0, keys.Length))
+            {
+                var obj = pool.DeleteByKey(keys[index]);
+                Assert.Equal(objs[index], obj);
+            }
+
+            Assert.True(pool.IsEmpty());
+        }
+
+        [Fact]
+        public void AddAndGetAll_WorksCorrectly()
+        {
+            // Arrange
+            var pool = new RoundRobinPool<string, string>();
+
+            var keys = new string[2] { "key1", "key2" };
+            var objs = new string[2] { "obj1", "obj2" };
+
+            // Act
+            foreach (var index in Enumerable.Range(0, keys.Length))
+            {
+                pool.Add(keys[index], objs[index]);
+            }
+
+            var poolObjects = pool.GetAll();
+
+            // Assert
+            Assert.Equal(keys.Length, poolObjects.Length);
+            foreach (var index in Enumerable.Range(0, keys.Length))
+            {
+                Assert.Equal(poolObjects[index], objs[index]);
+            }
+        }
+
+        [Fact]
+        public void AddAndGetByKey_WorksCorrectly()
+        {
+            // Arrange
+            var pool = new RoundRobinPool<string, string>();
+
+            var keys = new string[2] { "key1", "key2" };
+            var objs = new string[2] { "obj1", "obj2" };
+
+            // Act
+            foreach (var index in Enumerable.Range(0, keys.Length))
+            {
+                pool.Add(keys[index], objs[index]);
+            }
+
+            // Assert
+            foreach (var index in Enumerable.Range(0, keys.Length))
+            {
+                Assert.Equal(objs[index], pool.GetByKey(keys[index]));
+            }
+        }
+
+        [Fact]
+        public void AddObjectsByDuplicateKey_WorksCorrectly()
+        {
+            // Arrange
+            var pool = new RoundRobinPool<string, string>();
+
+            // Act
+            pool.Add("key", "obj1");
+            pool.Add("key", "obj2");
+
+            // Assert
+            Assert.Equal("obj2", pool.DeleteByKey("key"));
+            Assert.True(pool.IsEmpty());
+            Assert.Null(pool.DeleteByKey("key"));
+        }
+
+        [Fact]
+        public void AddAndGetNext_WorksCorrectly()
+        {
+            // Arrange
+            var pool = new RoundRobinPool<string, string>();
+
+            var keys = new string[2] { "key1", "key2" };
+            var objs = new string[2] { "obj1", "obj2" };
+
+            foreach (var index in Enumerable.Range(0, keys.Length))
+            {
+                pool.Add(keys[index], objs[index]);
+            }
+
+            // Act and Assert
+            var expected = new string[6] { "obj1", "obj2", "obj1", "obj2", "obj1", "obj2" };
+            foreach (var i in Enumerable.Range(0, expected.Length))
+            {
+                Assert.Equal(expected[i], pool.GetNext());
+            }
+        }
+    }
+}

--- a/tests/progaudi.tarantool.tests/progaudi.tarantool.tests.csproj
+++ b/tests/progaudi.tarantool.tests/progaudi.tarantool.tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="StackExchange.Redis" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
- added a few non-breaking changes in Box/IBox public interface (Do-methods and ConnectionGoesDown event handler), which are required for pooling implementation
- ConnectionPool class implemented, user can work with multiple instances of Tarantool in unified way (and use RequestMode to control request routing to ro/rw instances)
- ConnectionPool use round robin logic
- ConnectionPool use abstraction ITarantoolNodesSource in initial filling, so user can easily change the source of Tarantool nodes: config, etcd, etc
- ConnectionPool has autoreconnection logic: if node went down, it eliminates from pool, and special background reconnector starts to monitor its state and try to return it to pool back
- unit tests
- minor file reorganization: classes that implements inner Box machinery moved into Core folder

what is not implemented yet
- readme updates with example(s)
- monitoring of ro/rw state of nodes (ro can become rw after autofailover for example, ConnectionPool should update its state)
- autorenewal of nodes in pool, by timer for example (we can use ITarantoolNodesSource abstraction)
- zones/distances feature: ability to assign a zone/distance to each node and instruct pool to use the closest nodes as possible