### PR TITLE
Cleanup remnants of .NET Standard 1.4 support, remove dead code

### DIFF
--- a/src/progaudi.tarantool/NetworkStreamPhysicalConnection.cs
+++ b/src/progaudi.tarantool/NetworkStreamPhysicalConnection.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
 using ProGaudi.Tarantool.Client.Model;
 using ProGaudi.Tarantool.Client.Utils;
-
-#if PROGAUDI_NETCORE
-using System.Net;
-#endif
 
 namespace ProGaudi.Tarantool.Client
 {
@@ -76,7 +73,6 @@ namespace ProGaudi.Tarantool.Client
             return await _stream.ReadAsync(buffer, offset, count).ConfigureAwait(false);
         }
 
-#if PROGAUDI_NETCORE
         /// https://github.com/mongodb/mongo-csharp-driver/commit/9c2097f349d5096a04ea81b0c9ceb60c7e1acee4
         private static async Task ConnectAsync(Socket socket, string host, int port)
         {
@@ -102,18 +98,6 @@ namespace ProGaudi.Tarantool.Client
             // we should never get here...
             throw new InvalidOperationException("Unabled to resolve endpoint.");
         }
-#else
-        /// Stolen from corefx github
-        private static Task ConnectAsync(Socket socket, string host, int port)
-        {
-            return Task.Factory.FromAsync(
-                (targetHost, targetPort, callback, state) => ((Socket)state).BeginConnect(targetHost, targetPort, callback, state),
-                asyncResult => ((Socket)asyncResult.AsyncState).EndConnect(asyncResult),
-                host,
-                port,
-                socket);
-        }
-#endif
 
         public bool IsConnected => !_disposed && _stream != null;
 

--- a/src/progaudi.tarantool/progaudi.tarantool.csproj
+++ b/src/progaudi.tarantool/progaudi.tarantool.csproj
@@ -1,8 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net462;netstandard2.0;net60</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+  <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net60</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
@@ -22,9 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="MsgPack.Light" />
-    <PackageReference Include="System.Memory" />
-    <PackageReference Include="System.Net.NameResolution" />
-    <PackageReference Include="System.Threading.Thread" />
+    <PackageReference Include="System.Memory" Condition=" $(TargetFramework) == 'netstandard2.0' " />
   </ItemGroup>
 
   <ItemGroup>
@@ -73,10 +68,6 @@
       <DependentUpon>ValueTupleConverters.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <DefineConstants>$(DefineConstants);PROGAUDI_NETCORE</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\"/>


### PR DESCRIPTION
There's a modern piece of code in `NetworkStreamPhysicalConnection` that's disabled by conditional compilation when the target is not .NET Standard 1.4, and such a target is absent from the list of target frameworks. So the archaic APM workaround with `BeginConnect`/`EndConnect` is used instead. That was probably not intended.

Also .NET Framework 4.6.2 supports .NET Standard 2.0, there is no need for a separate build with .NET Framework target.