### PR TITLE
add 3.2.1 tarantool to tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,14 @@ services:
             TARANTOOL_USER_NAME: admin
             TARANTOOL_USER_PASSWORD: adminPassword
 
+    tarantool_3_2_1:
+        image: tarantool/tarantool:3.2.1
+        ports:
+            - "3311:3301"
+        environment:
+            TARANTOOL_USER_NAME: admin
+            TARANTOOL_USER_PASSWORD: adminPassword
+
     redis:
         image: redis:3.0-alpine
         command: redis-server


### PR DESCRIPTION
Updated docker compose to add the 3.2.1 version.